### PR TITLE
feat: opt-in HA knobs in all three app-template charts

### DIFF
--- a/charts/asm-app-template/Chart.yaml
+++ b/charts/asm-app-template/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.0.0
 description: A Helm chart for Kubernetes
 name: asm-app-template
 type: application
-version: 1.0.63
+version: 1.0.64

--- a/charts/asm-app-template/templates/deployment.yaml
+++ b/charts/asm-app-template/templates/deployment.yaml
@@ -26,8 +26,16 @@ spec:
     type: {{ $strategy }}
     {{- if eq $strategy "RollingUpdate" }}
     rollingUpdate:
+      {{- if hasKey .Values.deployment "maxUnavailable" }}
+      maxUnavailable: {{ .Values.deployment.maxUnavailable }}
+      {{- else }}
       maxUnavailable: {{ if eq (int $effectiveReplicas) 1 }}0{{ else }}1{{ end }}
+      {{- end }}
+      {{- if hasKey .Values.deployment "maxSurge" }}
+      maxSurge: {{ .Values.deployment.maxSurge }}
+      {{- else }}
       maxSurge: {{ if eq (int $effectiveReplicas) 1 }}1{{ else }}0{{ end }}
+      {{- end }}
     {{- end }}
   template:
     metadata:
@@ -44,12 +52,12 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: {{ .Values.deployment.topologySpread.whenUnsatisfiable | default "ScheduleAnyway" }}
           labelSelector:
             matchLabels:
               app: {{ .Values.appName }}
               # timestamp: {{ date "20060102150405" now | quote }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.noInterrupt.enabled }}
       serviceAccountName: no-interrupt-sa
       {{- end }}
@@ -158,7 +166,12 @@ spec:
         lifecycle:
           preStop:
             exec:
+              {{- $drain := int (.Values.deployment.preStopDrainSeconds | default 0) }}
+              {{- if gt $drain 0 }}
+              command: ["/bin/sh", "-c", "sleep {{ $drain }} && kill -TERM 1 && while kill -0 1 2>/dev/null; do sleep 1; done"]
+              {{- else }}
               command: ["/bin/sh", "-c", "kill -TERM 1 && while kill -0 1 2>/dev/null; do sleep 1; done"]
+              {{- end }}
         env:
         {{- range $key, $value := .Values.environments }}
         - name: {{ $key }}

--- a/charts/asm-app-template/templates/deployment.yaml
+++ b/charts/asm-app-template/templates/deployment.yaml
@@ -1,4 +1,10 @@
 {{- if or (eq .Values.type "app") (eq .Values.type "worker") }}
+{{- /* Guard: terminationGracePeriodSeconds must exceed preStopDrainSeconds. */ -}}
+{{- $tgps := int (.Values.deployment.terminationGracePeriodSeconds | default 60) -}}
+{{- $drain := int (.Values.deployment.preStopDrainSeconds | default 0) -}}
+{{- if and (gt $drain 0) (le $tgps $drain) -}}
+{{- fail (printf "deployment.preStopDrainSeconds (%d) must be < deployment.terminationGracePeriodSeconds (%d); otherwise the kubelet will SIGKILL the pod before the drain completes" $drain $tgps) -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/asm-app-template/templates/ingress.yaml
+++ b/charts/asm-app-template/templates/ingress.yaml
@@ -10,6 +10,20 @@ metadata:
     alb.ingress.kubernetes.io/target-type: {{ .Values.ingress.target}}
     alb.ingress.kubernetes.io/security-groups: {{ .Values.ingress.sg }}
     alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.healthcheck.path }}
+    {{- with .Values.ingress.healthcheck }}
+    {{- if .intervalSeconds }}
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: {{ .intervalSeconds | quote }}
+    {{- end }}
+    {{- if .timeoutSeconds }}
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: {{ .timeoutSeconds | quote }}
+    {{- end }}
+    {{- if .healthyThreshold }}
+    alb.ingress.kubernetes.io/healthy-threshold-count: {{ .healthyThreshold | quote }}
+    {{- end }}
+    {{- if .unhealthyThreshold }}
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: {{ .unhealthyThreshold | quote }}
+    {{- end }}
+    {{- end }}
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.group }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443},{"HTTP":80}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}

--- a/charts/asm-app-template/templates/ingress.yaml
+++ b/charts/asm-app-template/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443},{"HTTP":80}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/load-balancer-attributes: deletion_protection.enabled=true,routing.http.preserve_host_header.enabled=true,routing.http.xff_header_processing.mode=preserve,idle_timeout.timeout_seconds=300
+    {{- if .Values.ingress.targetGroupAttributes }}
+    alb.ingress.kubernetes.io/target-group-attributes: {{ .Values.ingress.targetGroupAttributes | quote }}
+    {{- end }}
     alb.ingress.kubernetes.io/actions.{{ .Values.appName }}: '{ "Type": "forward", "ForwardConfig": { "TargetGroups": [ { "Weight": 100, "ServiceName": "{{ .Values.appName }}", "ServicePort": "{{ (index .Values.service.ports 0).port }}" } ] } }'
     alb.ingress.kubernetes.io/tags: Owner=santiago.hernandez@strike.sh,Environment={{ .Values.envShort }},Monitoring=Datadog,ContainsUserData=true,UserDataStored=false,Description=InternalALBGroup,Repo=helm-apps
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.appName }}.{{ .Values.envShort }}.{{ .Values.ingress.domain }}

--- a/charts/asm-app-template/values.yaml
+++ b/charts/asm-app-template/values.yaml
@@ -37,8 +37,10 @@ replicaCount: 2
 deployment:
   strategy: RollingUpdate
   # Override rolling-update surge / unavailable. Leave unset to use the
-  # chart default (replicas==1 -> maxSurge:1,maxUnavailable:0;
-  #                replicas>1  -> maxSurge:0,maxUnavailable:1).
+  # chart default, which is based on the *effective* replica count
+  # (hpa.minReplicas when HPA is enabled, otherwise replicaCount):
+  #   effectiveReplicas == 1 -> maxSurge:1, maxUnavailable:0
+  #   effectiveReplicas  > 1 -> maxSurge:0, maxUnavailable:1
   # Recommended for HA HTTP-serving apps: maxSurge:1, maxUnavailable:0.
   # maxSurge: 1
   # maxUnavailable: 0

--- a/charts/asm-app-template/values.yaml
+++ b/charts/asm-app-template/values.yaml
@@ -76,6 +76,17 @@ ingress:
   # Recommended for graceful pod drain: "deregistration_delay.timeout_seconds=30"
   # Leave empty to use AWS defaults.
   targetGroupAttributes: ""
+  # ALB target-group health check tuning. Each field, when empty, falls back
+  # to the AWS default (interval=15s, timeout=5s, healthy=5, unhealthy=2 for
+  # ip targets). Bumping `unhealthyThreshold` to e.g. 5 gives ~75s of
+  # tolerance before a target is marked unhealthy — useful for HA apps that
+  # share an ALB ingress group and occasionally see transient probe slowness
+  # during reconciliation bursts.
+  healthcheck:
+    intervalSeconds: ""
+    timeoutSeconds: ""
+    healthyThreshold: ""
+    unhealthyThreshold: ""
   # extraHosts: Additional hosts to expose with the same configuration
   # Example:
   # extraHosts:

--- a/charts/asm-app-template/values.yaml
+++ b/charts/asm-app-template/values.yaml
@@ -36,6 +36,24 @@ resources:
 replicaCount: 2
 deployment:
   strategy: RollingUpdate
+  # Override rolling-update surge / unavailable. Leave unset to use the
+  # chart default (replicas==1 -> maxSurge:1,maxUnavailable:0;
+  #                replicas>1  -> maxSurge:0,maxUnavailable:1).
+  # Recommended for HA HTTP-serving apps: maxSurge:1, maxUnavailable:0.
+  # maxSurge: 1
+  # maxUnavailable: 0
+  # Seconds to sleep before SIGTERM in preStop, to let the ALB drain in-flight
+  # requests before the container stops accepting connections. Bounded by
+  # terminationGracePeriodSeconds below — keep at least ~30s of headroom.
+  # Default 25 covers the ALB target-group deregistration window. Set to 0
+  # to opt out (e.g. for workers where graceful drain has no effect).
+  preStopDrainSeconds: 25
+  # Pod terminationGracePeriodSeconds. Must be greater than preStopDrainSeconds.
+  terminationGracePeriodSeconds: 60
+  topologySpread:
+    # Set to DoNotSchedule to force pods onto distinct nodes (stricter HA;
+    # may leave pods Pending if the cluster lacks enough distinct nodes).
+    whenUnsatisfiable: ScheduleAnyway
   specs:
     labels:
       example: thislabel
@@ -54,6 +72,10 @@ ingress:
   domain: westrike.top
   group: "core"
   certificate: arn:aws:acm:us-east-1:287981551800:certificate/7b97d133-a5e6-4d9f-bef7-f77f8aab38f9
+  # Per-target-group ALB attributes (comma-separated key=value pairs).
+  # Recommended for graceful pod drain: "deregistration_delay.timeout_seconds=30"
+  # Leave empty to use AWS defaults.
+  targetGroupAttributes: ""
   # extraHosts: Additional hosts to expose with the same configuration
   # Example:
   # extraHosts:

--- a/charts/live-app-template/Chart.yaml
+++ b/charts/live-app-template/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.0.0
 description: A Helm chart for Kubernetes
 name: live-app-template
 type: application
-version: 1.0.63
+version: 1.0.64

--- a/charts/live-app-template/templates/deployment.yaml
+++ b/charts/live-app-template/templates/deployment.yaml
@@ -26,8 +26,16 @@ spec:
     type: {{ $strategy }}
     {{- if eq $strategy "RollingUpdate" }}
     rollingUpdate:
+      {{- if hasKey .Values.deployment "maxUnavailable" }}
+      maxUnavailable: {{ .Values.deployment.maxUnavailable }}
+      {{- else }}
       maxUnavailable: {{ if eq (int $effectiveReplicas) 1 }}0{{ else }}1{{ end }}
+      {{- end }}
+      {{- if hasKey .Values.deployment "maxSurge" }}
+      maxSurge: {{ .Values.deployment.maxSurge }}
+      {{- else }}
       maxSurge: {{ if eq (int $effectiveReplicas) 1 }}1{{ else }}0{{ end }}
+      {{- end }}
     {{- end }}
   template:
     metadata:
@@ -44,12 +52,12 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: {{ .Values.deployment.topologySpread.whenUnsatisfiable | default "ScheduleAnyway" }}
           labelSelector:
             matchLabels:
               app: {{ .Values.appName }}
               # timestamp: {{ date "20060102150405" now | quote }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.noInterrupt.enabled }}
       serviceAccountName: no-interrupt-sa
       {{- end }}
@@ -158,7 +166,12 @@ spec:
         lifecycle:
           preStop:
             exec:
+              {{- $drain := int (.Values.deployment.preStopDrainSeconds | default 0) }}
+              {{- if gt $drain 0 }}
+              command: ["/bin/sh", "-c", "sleep {{ $drain }} && kill -TERM 1 && while kill -0 1 2>/dev/null; do sleep 1; done"]
+              {{- else }}
               command: ["/bin/sh", "-c", "kill -TERM 1 && while kill -0 1 2>/dev/null; do sleep 1; done"]
+              {{- end }}
         env:
         {{- range $key, $value := .Values.environments }}
         - name: {{ $key }}

--- a/charts/live-app-template/templates/deployment.yaml
+++ b/charts/live-app-template/templates/deployment.yaml
@@ -1,4 +1,10 @@
 {{- if or (eq .Values.type "app") (eq .Values.type "worker") }}
+{{- /* Guard: terminationGracePeriodSeconds must exceed preStopDrainSeconds. */ -}}
+{{- $tgps := int (.Values.deployment.terminationGracePeriodSeconds | default 60) -}}
+{{- $drain := int (.Values.deployment.preStopDrainSeconds | default 0) -}}
+{{- if and (gt $drain 0) (le $tgps $drain) -}}
+{{- fail (printf "deployment.preStopDrainSeconds (%d) must be < deployment.terminationGracePeriodSeconds (%d); otherwise the kubelet will SIGKILL the pod before the drain completes" $drain $tgps) -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/live-app-template/templates/ingress.yaml
+++ b/charts/live-app-template/templates/ingress.yaml
@@ -10,6 +10,20 @@ metadata:
     alb.ingress.kubernetes.io/target-type: {{ .Values.ingress.target}}
     alb.ingress.kubernetes.io/security-groups: {{ .Values.ingress.sg }}
     alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.healthcheck.path }}
+    {{- with .Values.ingress.healthcheck }}
+    {{- if .intervalSeconds }}
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: {{ .intervalSeconds | quote }}
+    {{- end }}
+    {{- if .timeoutSeconds }}
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: {{ .timeoutSeconds | quote }}
+    {{- end }}
+    {{- if .healthyThreshold }}
+    alb.ingress.kubernetes.io/healthy-threshold-count: {{ .healthyThreshold | quote }}
+    {{- end }}
+    {{- if .unhealthyThreshold }}
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: {{ .unhealthyThreshold | quote }}
+    {{- end }}
+    {{- end }}
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.group }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443},{"HTTP":80}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}

--- a/charts/live-app-template/templates/ingress.yaml
+++ b/charts/live-app-template/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443},{"HTTP":80}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/load-balancer-attributes: deletion_protection.enabled=true,routing.http.preserve_host_header.enabled=true,routing.http.xff_header_processing.mode=preserve,idle_timeout.timeout_seconds=300
+    {{- if .Values.ingress.targetGroupAttributes }}
+    alb.ingress.kubernetes.io/target-group-attributes: {{ .Values.ingress.targetGroupAttributes | quote }}
+    {{- end }}
     alb.ingress.kubernetes.io/actions.{{ .Values.appName }}: '{ "Type": "forward", "ForwardConfig": { "TargetGroups": [ { "Weight": 100, "ServiceName": "{{ .Values.appName }}", "ServicePort": "{{ (index .Values.service.ports 0).port }}" } ] } }'
     alb.ingress.kubernetes.io/tags: Owner=santiago.hernandez@strike.sh,Environment={{ .Values.envShort }},Monitoring=Datadog,ContainsUserData=true,UserDataStored=false,Description=InternalALBGroup,Repo=helm-apps
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.appName }}.{{ .Values.envShort }}.{{ .Values.ingress.domain }}

--- a/charts/live-app-template/values.yaml
+++ b/charts/live-app-template/values.yaml
@@ -37,8 +37,10 @@ replicaCount: 2
 deployment:
   strategy: RollingUpdate
   # Override rolling-update surge / unavailable. Leave unset to use the
-  # chart default (replicas==1 -> maxSurge:1,maxUnavailable:0;
-  #                replicas>1  -> maxSurge:0,maxUnavailable:1).
+  # chart default, which is based on the *effective* replica count
+  # (hpa.minReplicas when HPA is enabled, otherwise replicaCount):
+  #   effectiveReplicas == 1 -> maxSurge:1, maxUnavailable:0
+  #   effectiveReplicas  > 1 -> maxSurge:0, maxUnavailable:1
   # Recommended for HA HTTP-serving apps: maxSurge:1, maxUnavailable:0.
   # maxSurge: 1
   # maxUnavailable: 0

--- a/charts/live-app-template/values.yaml
+++ b/charts/live-app-template/values.yaml
@@ -76,6 +76,17 @@ ingress:
   # Recommended for graceful pod drain: "deregistration_delay.timeout_seconds=30"
   # Leave empty to use AWS defaults.
   targetGroupAttributes: ""
+  # ALB target-group health check tuning. Each field, when empty, falls back
+  # to the AWS default (interval=15s, timeout=5s, healthy=5, unhealthy=2 for
+  # ip targets). Bumping `unhealthyThreshold` to e.g. 5 gives ~75s of
+  # tolerance before a target is marked unhealthy — useful for HA apps that
+  # share an ALB ingress group and occasionally see transient probe slowness
+  # during reconciliation bursts.
+  healthcheck:
+    intervalSeconds: ""
+    timeoutSeconds: ""
+    healthyThreshold: ""
+    unhealthyThreshold: ""
   # extraHosts: Additional hosts to expose with the same configuration
   # Example:
   # extraHosts:

--- a/charts/live-app-template/values.yaml
+++ b/charts/live-app-template/values.yaml
@@ -36,6 +36,24 @@ resources:
 replicaCount: 2
 deployment:
   strategy: RollingUpdate
+  # Override rolling-update surge / unavailable. Leave unset to use the
+  # chart default (replicas==1 -> maxSurge:1,maxUnavailable:0;
+  #                replicas>1  -> maxSurge:0,maxUnavailable:1).
+  # Recommended for HA HTTP-serving apps: maxSurge:1, maxUnavailable:0.
+  # maxSurge: 1
+  # maxUnavailable: 0
+  # Seconds to sleep before SIGTERM in preStop, to let the ALB drain in-flight
+  # requests before the container stops accepting connections. Bounded by
+  # terminationGracePeriodSeconds below — keep at least ~30s of headroom.
+  # Default 25 covers the ALB target-group deregistration window. Set to 0
+  # to opt out (e.g. for workers where graceful drain has no effect).
+  preStopDrainSeconds: 25
+  # Pod terminationGracePeriodSeconds. Must be greater than preStopDrainSeconds.
+  terminationGracePeriodSeconds: 60
+  topologySpread:
+    # Set to DoNotSchedule to force pods onto distinct nodes (stricter HA;
+    # may leave pods Pending if the cluster lacks enough distinct nodes).
+    whenUnsatisfiable: ScheduleAnyway
   specs:
     labels:
       example: thislabel
@@ -54,6 +72,10 @@ ingress:
   domain: westrike.top
   group: "core"
   certificate: arn:aws:acm:us-east-1:790809641511:certificate/5a96472b-2566-49ca-8b3e-25349881f936
+  # Per-target-group ALB attributes (comma-separated key=value pairs).
+  # Recommended for graceful pod drain: "deregistration_delay.timeout_seconds=30"
+  # Leave empty to use AWS defaults.
+  targetGroupAttributes: ""
   # extraHosts: Additional hosts to expose with the same configuration
   # Example:
   # extraHosts:

--- a/charts/stg-app-template/Chart.yaml
+++ b/charts/stg-app-template/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.0.0
 description: A Helm chart for Kubernetes
 name: stg-app-template
 type: application
-version: 1.0.64
+version: 1.0.65

--- a/charts/stg-app-template/templates/deployment.yaml
+++ b/charts/stg-app-template/templates/deployment.yaml
@@ -1,4 +1,10 @@
 {{- if or (eq .Values.type "app") (eq .Values.type "worker") }}
+{{- /* Guard: terminationGracePeriodSeconds must exceed preStopDrainSeconds. */ -}}
+{{- $tgps := int (.Values.deployment.terminationGracePeriodSeconds | default 60) -}}
+{{- $drain := int (.Values.deployment.preStopDrainSeconds | default 0) -}}
+{{- if and (gt $drain 0) (le $tgps $drain) -}}
+{{- fail (printf "deployment.preStopDrainSeconds (%d) must be < deployment.terminationGracePeriodSeconds (%d); otherwise the kubelet will SIGKILL the pod before the drain completes" $drain $tgps) -}}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/stg-app-template/templates/deployment.yaml
+++ b/charts/stg-app-template/templates/deployment.yaml
@@ -27,8 +27,16 @@ spec:
     type: {{ $strategy }}
     {{- if eq $strategy "RollingUpdate" }}
     rollingUpdate:
+      {{- if hasKey .Values.deployment "maxUnavailable" }}
+      maxUnavailable: {{ .Values.deployment.maxUnavailable }}
+      {{- else }}
       maxUnavailable: {{ if eq (int $effectiveReplicas) 1 }}0{{ else }}1{{ end }}
+      {{- end }}
+      {{- if hasKey .Values.deployment "maxSurge" }}
+      maxSurge: {{ .Values.deployment.maxSurge }}
+      {{- else }}
       maxSurge: {{ if eq (int $effectiveReplicas) 1 }}1{{ else }}0{{ end }}
+      {{- end }}
     {{- end }}
   template:
     metadata:
@@ -45,12 +53,12 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: "kubernetes.io/hostname"
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: {{ .Values.deployment.topologySpread.whenUnsatisfiable | default "ScheduleAnyway" }}
           labelSelector:
             matchLabels:
               app: {{ .Values.appName }}
               # timestamp: {{ date "20060102150405" now | quote }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds | default 60 }}
       {{- if .Values.noInterrupt.enabled }}
       serviceAccountName: no-interrupt-sa
       {{- end }}
@@ -159,7 +167,12 @@ spec:
         lifecycle:
           preStop:
             exec:
+              {{- $drain := int (.Values.deployment.preStopDrainSeconds | default 0) }}
+              {{- if gt $drain 0 }}
+              command: ["/bin/sh", "-c", "sleep {{ $drain }} && kill -TERM 1 && while kill -0 1 2>/dev/null; do sleep 1; done"]
+              {{- else }}
               command: ["/bin/sh", "-c", "kill -TERM 1 && while kill -0 1 2>/dev/null; do sleep 1; done"]
+              {{- end }}
         env:
         {{- range $key, $value := .Values.environments }}
         - name: {{ $key }}

--- a/charts/stg-app-template/templates/ingress.yaml
+++ b/charts/stg-app-template/templates/ingress.yaml
@@ -10,6 +10,20 @@ metadata:
     alb.ingress.kubernetes.io/target-type: {{ .Values.ingress.target}}
     alb.ingress.kubernetes.io/security-groups: {{ .Values.ingress.sg }}
     alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.healthcheck.path }}
+    {{- with .Values.ingress.healthcheck }}
+    {{- if .intervalSeconds }}
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: {{ .intervalSeconds | quote }}
+    {{- end }}
+    {{- if .timeoutSeconds }}
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: {{ .timeoutSeconds | quote }}
+    {{- end }}
+    {{- if .healthyThreshold }}
+    alb.ingress.kubernetes.io/healthy-threshold-count: {{ .healthyThreshold | quote }}
+    {{- end }}
+    {{- if .unhealthyThreshold }}
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: {{ .unhealthyThreshold | quote }}
+    {{- end }}
+    {{- end }}
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.group }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443},{"HTTP":80}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}

--- a/charts/stg-app-template/templates/ingress.yaml
+++ b/charts/stg-app-template/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443},{"HTTP":80}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/load-balancer-attributes: deletion_protection.enabled=false,routing.http.preserve_host_header.enabled=true,routing.http.xff_header_processing.mode=preserve,idle_timeout.timeout_seconds=300
+    {{- if .Values.ingress.targetGroupAttributes }}
+    alb.ingress.kubernetes.io/target-group-attributes: {{ .Values.ingress.targetGroupAttributes | quote }}
+    {{- end }}
     alb.ingress.kubernetes.io/actions.{{ .Values.appName }}: '{ "Type": "forward", "ForwardConfig": { "TargetGroups": [ { "Weight": 100, "ServiceName": "{{ .Values.appName }}", "ServicePort": "{{ (index .Values.service.ports 0).port }}" } ] } }'
     alb.ingress.kubernetes.io/tags: Owner=santiago.hernandez@strike.sh,Environment={{ .Values.envShort }},Monitoring=Datadog,ContainsUserData=true,UserDataStored=false,Description=InternalALBGroup,Repo=helm-apps
     {{- if ne .Values.ingress.domain "preview.strike.sh" }}

--- a/charts/stg-app-template/values.yaml
+++ b/charts/stg-app-template/values.yaml
@@ -36,6 +36,24 @@ resources:
 replicaCount: 1
 deployment:
   strategy: RollingUpdate
+  # Override rolling-update surge / unavailable. Leave unset to use the
+  # chart default (replicas==1 -> maxSurge:1,maxUnavailable:0;
+  #                replicas>1  -> maxSurge:0,maxUnavailable:1).
+  # Recommended for HA HTTP-serving apps: maxSurge:1, maxUnavailable:0.
+  # maxSurge: 1
+  # maxUnavailable: 0
+  # Seconds to sleep before SIGTERM in preStop, to let the ALB drain in-flight
+  # requests before the container stops accepting connections. Bounded by
+  # terminationGracePeriodSeconds below — keep at least ~30s of headroom.
+  # Default 25 covers the ALB target-group deregistration window. Set to 0
+  # to opt out (e.g. for workers where graceful drain has no effect).
+  preStopDrainSeconds: 25
+  # Pod terminationGracePeriodSeconds. Must be greater than preStopDrainSeconds.
+  terminationGracePeriodSeconds: 60
+  topologySpread:
+    # Set to DoNotSchedule to force pods onto distinct nodes (stricter HA;
+    # may leave pods Pending if the cluster lacks enough distinct nodes).
+    whenUnsatisfiable: ScheduleAnyway
   specs:
     labels:
       example: thislabel
@@ -54,6 +72,10 @@ ingress:
   domain: westrike.top
   group: "core"
   certificate: arn:aws:acm:us-east-2:317814227242:certificate/614d5719-349a-4933-acce-ddf7d4239ce8
+  # Per-target-group ALB attributes (comma-separated key=value pairs).
+  # Recommended for graceful pod drain: "deregistration_delay.timeout_seconds=30"
+  # Leave empty to use AWS defaults.
+  targetGroupAttributes: ""
   # extraHosts: Additional hosts to expose with the same configuration
   # Example:
   # extraHosts:

--- a/charts/stg-app-template/values.yaml
+++ b/charts/stg-app-template/values.yaml
@@ -76,6 +76,17 @@ ingress:
   # Recommended for graceful pod drain: "deregistration_delay.timeout_seconds=30"
   # Leave empty to use AWS defaults.
   targetGroupAttributes: ""
+  # ALB target-group health check tuning. Each field, when empty, falls back
+  # to the AWS default (interval=15s, timeout=5s, healthy=5, unhealthy=2 for
+  # ip targets). Bumping `unhealthyThreshold` to e.g. 5 gives ~75s of
+  # tolerance before a target is marked unhealthy — useful for HA apps that
+  # share an ALB ingress group and occasionally see transient probe slowness
+  # during reconciliation bursts.
+  healthcheck:
+    intervalSeconds: ""
+    timeoutSeconds: ""
+    healthyThreshold: ""
+    unhealthyThreshold: ""
   # extraHosts: Additional hosts to expose with the same configuration
   # Example:
   # extraHosts:

--- a/charts/stg-app-template/values.yaml
+++ b/charts/stg-app-template/values.yaml
@@ -37,8 +37,10 @@ replicaCount: 1
 deployment:
   strategy: RollingUpdate
   # Override rolling-update surge / unavailable. Leave unset to use the
-  # chart default (replicas==1 -> maxSurge:1,maxUnavailable:0;
-  #                replicas>1  -> maxSurge:0,maxUnavailable:1).
+  # chart default, which is based on the *effective* replica count
+  # (hpa.minReplicas when HPA is enabled, otherwise replicaCount):
+  #   effectiveReplicas == 1 -> maxSurge:1, maxUnavailable:0
+  #   effectiveReplicas  > 1 -> maxSurge:0, maxUnavailable:1
   # Recommended for HA HTTP-serving apps: maxSurge:1, maxUnavailable:0.
   # maxSurge: 1
   # maxUnavailable: 0


### PR DESCRIPTION
## Why

`demo-straik` (and other public-facing portals) occasionally returns 502 Bad Gateway from Cloudflare. Investigation found two distinct failure modes:

1. **Pod termination races**: the `preStop` hook is `kill -TERM 1` with no sleep, so Node closes its listener **before** the ALB deregisters the pod IP from the target group → in-flight requests hit a dead pod → 502. This affects deploys, OOM kills, evictions, node drains.
2. **Shared-ALB reconciliation noise**: the ALB ingress group `core` has 49 TGBs in stg. Any sibling change triggers the aws-load-balancer-controller to walk all 49 — during these bursts, demo's targets can transiently appear unhealthy (default unhealthy-threshold is 2 misses = ~30s window). With only 2 replicas and `maxSurge: 0 / maxUnavailable: 1` hardcoded, a single misclassified target = 502.

## What

Adds opt-in HA knobs to `stg-app-template`, `live-app-template`, and `asm-app-template`. **One default is flipped** (`preStopDrainSeconds: 0 → 25`); everything else is pure opt-in.

### `deployment.*` knobs

| Knob | Old | New default | Notes |
|---|---|---|---|
| `preStopDrainSeconds` | hardcoded 0 | **25** | Zero-risk: bounded by `terminationGracePeriodSeconds: 60`, 35s headroom. Workers see a slightly slower shutdown (no traffic impact). |
| `maxSurge` / `maxUnavailable` | hardcoded (replicas-based) | unchanged (opt-in) | Surge requires +1 pod capacity and can break workers with single-instance assumptions. |
| `terminationGracePeriodSeconds` | hardcoded 60 | unchanged (60) | Now overridable; must exceed `preStopDrainSeconds`. |
| `topologySpread.whenUnsatisfiable` | hardcoded `ScheduleAnyway` | unchanged (opt-in) | `DoNotSchedule` pins pods Pending if the cluster lacks enough distinct nodes. |

### `ingress.*` knobs

| Knob | Old | New default | Notes |
|---|---|---|---|
| `targetGroupAttributes` | annotation absent | unchanged (`""`, opt-in) | Lowering deregistration_delay can cut websocket / SSE / large-download connections. |
| `healthcheck.intervalSeconds` | annotation absent (AWS default 15) | unchanged (opt-in) | Tune target-group health check interval. |
| `healthcheck.timeoutSeconds` | annotation absent (AWS default 5) | unchanged (opt-in) | |
| `healthcheck.healthyThreshold` | annotation absent (AWS default 5) | unchanged (opt-in) | |
| `healthcheck.unhealthyThreshold` | annotation absent (AWS default 2) | unchanged (opt-in) | Bump to 5 (~75s tolerance) for HA apps in noisy shared ALB groups. |

Existing consumers do not need to update their `values.yaml`. The only rendered change for everyone is the `preStop` command, which now sleeps 25s before SIGTERM.

## Chart version bumps

- `stg-app-template`: 1.0.64 → 1.0.65
- `live-app-template`: 1.0.63 → 1.0.64
- `asm-app-template`: 1.0.63 → 1.0.64

## Verification

`helm template` of all three charts with representative real-world values:

```
$ diff <render-with-old-chart> <render-with-new-chart>
< command: ["/bin/sh", "-c", "kill -TERM 1 && ..."]
> command: ["/bin/sh", "-c", "sleep 25 && kill -TERM 1 && ..."]
```

Only the `preStop` command changes for existing consumers. With opt-in knobs set, the diff shows exactly the expected additions (surge/unavailable flip, topologySpread DoNotSchedule, target-group-attributes / unhealthy-threshold-count annotations, etc).

## Rollout plan

1. Merge this PR → CI publishes the new chart versions.
2. In the `straik` repo, bump `apps/clients/cloud/demo/Chart.yaml` to `1.0.65` and turn on the remaining opt-in knobs (separate PR — already drafted).
3. ArgoCD sync rolls demo with the HA settings — closes the 502 loop for deploys, restarts, and (with `unhealthyThreshold: 5`) for shared-ALB reconciliation noise.
4. Every other app that adopts the bumped chart on its next release automatically gets the 25s drain. No values change required.